### PR TITLE
do not destructure startup tasks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,8 +76,7 @@ export class WindowsStoreAutoLaunch {
     const startupTasks = await WindowsStoreAutoLaunch.getStartupTasks();
 
     if (startupTasks && startupTasks.length > 0) {
-      const [ startupTask ] = startupTasks;
-      return startupTask;
+      return startupTasks[0];
     } else {
       return null;
     }


### PR DESCRIPTION
Thanks for the great work on this module :)

After Babel compilation I receive a JS runtime error startupTasks is not iterable.

I can only presume startupTasks is a keyed object and hence fails at the destructure. It feels safer to use bracket property access notation here (and this fixes the issue I was having).